### PR TITLE
Add automated contract tests for update check (closes #12)

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -373,4 +373,8 @@ main() {
   esac
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "${0}" && -z "$ACI_TEST_MODE" ]]; then
+  main
+fi
+
+

--- a/tests/check_for_updates.contract.md
+++ b/tests/check_for_updates.contract.md
@@ -1,0 +1,19 @@
+# Contract: check_for_updates
+
+This document defines the expected behavior of the `check_for_updates` function.
+
+## Expected outcomes
+
+| Scenario                          | Expected exit code |
+|----------------------------------|--------------------|
+| No internet connection           | 0                  |
+| GitHub token not set             | 1                  |
+| GitHub API error / invalid JSON  | 1                  |
+| New version available            | 2                  |
+| Already on latest version        | 0                  |
+
+## Notes
+
+- This function must not require Arduino hardware
+- Designed to be testable in CI
+- Exit codes are part of the public contract

--- a/tests/check_for_updates.test.sh
+++ b/tests/check_for_updates.test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Test: check_for_updates without GitHub token
+set -x
+
+export ACI_TEST_MODE=1
+unset ACI_GITHUB_TOKEN
+
+ping() {
+  return 1
+}
+
+source ./main.sh
+
+check_for_updates
+exit_code=$?
+
+if [ "$exit_code" -ne 1 ]; then
+  echo "❌ Expected exit code 1 when ACI_GITHUB_TOKEN is missing, got $exit_code"
+  exit 1
+fi
+
+echo "✅ check_for_updates returns 1 when GitHub token is missing"


### PR DESCRIPTION
This PR implements initial automated contract and integration tests for the update check functionality as discussed in Issue #12.

## What’s Included

- Contract definition for expected update-check behavior
- Bash-based test covering missing GitHub token scenario
- Structured test file inside `tests/` directory
- Designed to be CI-friendly (Linux-based environments)

## Test Coverage

The test validates:
- `check_for_updates` returns exit code 1 when `ACI_GITHUB_TOKEN` is missing
- Expected behavior remains stable across updates

## Notes

- Tests are written for Unix/Linux environments and may not fully execute on Windows without a proper bash environment.
- Designed primarily for CI validation.

Closes #12
