### PR TITLE
Title: feat: implement validated baud rate selection for Serial Monitor

### DIFF
--- a/bin/aci.sh
+++ b/bin/aci.sh
@@ -12,7 +12,7 @@ sketch_file=""
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 serial_monitor() {
-  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" --header "Select Baud Rate")
+  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
   arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config baudrate=$baud_rate
   trap 'gum confirm "Return to Homepage ?" && main || exit' SIGINT
 

--- a/bin/aci.sh
+++ b/bin/aci.sh
@@ -12,8 +12,8 @@ sketch_file=""
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 serial_monitor() {
-  local baud_rate=$(gum input --placeholder "Baud Rate")
-  arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config $baud_rate
+  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" --header "Select Baud Rate")
+  arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config baudrate=$baud_rate
   trap 'gum confirm "Return to Homepage ?" && main || exit' SIGINT
 
   echo "Press Ctrl+C again"

--- a/bin/aci.sh
+++ b/bin/aci.sh
@@ -13,6 +13,9 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 serial_monitor() {
   local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
+  if [ -z "$baud_rate" ]; then
+    main
+  fi
   arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config baudrate=$baud_rate
   trap 'gum confirm "Return to Homepage ?" && main || exit' SIGINT
 

--- a/main.sh
+++ b/main.sh
@@ -51,6 +51,9 @@ install_dependencies() {
 
 serial_monitor() {
   local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
+  if [ -z "$baud_rate" ]; then
+    main
+  fi
   arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config baudrate=$baud_rate
   trap 'gum confirm "Return to Homepage ?" && main || exit' SIGINT
 

--- a/main.sh
+++ b/main.sh
@@ -50,8 +50,8 @@ install_dependencies() {
 }
 
 serial_monitor() {
-  local baud_rate=$(gum input --placeholder "Baud Rate")
-  arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config $baud_rate
+  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" --header "Select Baud Rate")
+  arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config baudrate=$baud_rate
   trap 'gum confirm "Return to Homepage ?" && main || exit' SIGINT
 
   echo "Press Ctrl+C again"

--- a/main.sh
+++ b/main.sh
@@ -50,7 +50,7 @@ install_dependencies() {
 }
 
 serial_monitor() {
-  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" --header "Select Baud Rate")
+  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
   arduino-cli monitor -p $SERIAL_PORT -b $FQBN_SELECTED --config baudrate=$baud_rate
   trap 'gum confirm "Return to Homepage ?" && main || exit' SIGINT
 

--- a/src/chapter_6.md
+++ b/src/chapter_6.md
@@ -36,8 +36,8 @@ void loop() {
 Once these are done, in the homepage , navigate to the **Serial Monitor** Option using the arrow keys and
 press **Enter**. 
 
-Now an Input dialog box appears that prompts you to enter the Baud Rate you used in your program (9600, 
-15200 etc.). Enter the correct baud rate you used and press **Enter**. 
+Now a selection menu appears that prompts you to select the Baud Rate you used in your program (9600, 
+115200 etc.). Select the correct baud rate you used and press **Enter**. 
 
 The Serial Monitor is now open for business. To exit the serial monitor, press *CTRL + C* 2 times. 
 The second time, you will be prompted for confimation to return to the homepage. Choose what you want


### PR DESCRIPTION
#35 

**Description**
This PR replaces the manual free-text input for the serial monitor's baud rate with a selection menu using gum choose. This eliminates the risk of typos or non-standard configurations that can cause arduino-cli monitor to fail or display corrupted data.

**Key Changes:**
Validation Menu: Replaced the gum input prompt with a gum choose selection menu.
Expanded Support: Populated the menu with standard baud rates ranging from 300 to 2,000,000, ensuring compatibility with modern boards like ESP32/ESP8266.
Safety Handling: Added a check to handle cases where the user cancels the selection (e.g., pressing Esc). The script now returns to the main menu instead of attempting to run the monitor with an empty value.
Configuration Fix: Updated the monitor command to use the explicit baudrate= configuration flag for better reliability.
Documentation: Updated the user guide in 
src/chapter_6.md
 to reflect the new interaction flow.
Files Modified:
main.sh
: Primary script logic for the serial monitor.
bin/aci.sh
: Binary distribution script.
src/chapter_6.md
: Documentation updates.
**Verification**
Verified shell script syntax for all changes.
Ensured the gum choose menu displays correctly with the new header.
Confirmed that cancelling the menu returns the user safely to the homepage.