### PR TITLE
feat(serial): add comprehensive baud rate selection menu

### DIFF
--- a/bin/aci.sh
+++ b/bin/aci.sh
@@ -20,7 +20,7 @@ run_timer() {
 }
 
 serial_monitor() {
-  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
+  local baud_rate=$(gum choose "300" "600" "1200" "2400" "4800" "9600" "14400" "19200" "28800" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
   if [ -z "$baud_rate" ]; then
     main
   fi

--- a/main.sh
+++ b/main.sh
@@ -78,7 +78,7 @@ install_dependencies() {
 }
 
 serial_monitor() {
-  local baud_rate=$(gum choose "300" "1200" "2400" "4800" "9600" "19200" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
+  local baud_rate=$(gum choose "300" "600" "1200" "2400" "4800" "9600" "14400" "19200" "28800" "38400" "57600" "115200" "230400" "250000" "500000" "1000000" "2000000" --header "Select Baud Rate")
   if [ -z "$baud_rate" ]; then
     main
   fi


### PR DESCRIPTION
#35 



## Which issue does this PR close?

- Closes # (if applicable)

## Rationale for this change

When starting the serial monitor, providing standard baud rate options prevents users from entering invalid values that cause communication failures or display garbage data. This change ensures a more robust and user-friendly experience by replacing/enhancing the selection menu with a comprehensive list of standard rates.

## What changes are included in this PR?

- Added more standard baud rates to the selection menu: `600`, `14400`, and `28800`.
- Updated [main.sh](cci:7://file:///d:/OSCG/ddh/arduino-cli-interactive/main.sh:0:0-0:0) to include the expanded list in the `gum choose` menu for the Serial Monitor.
- Synchronized [bin/aci.sh](cci:7://file:///d:/OSCG/ddh/arduino-cli-interactive/bin/aci.sh:0:0-0:0) with the same baud rate selection improvements for consistency across different installation methods.

## Are these changes tested?

Yes, manual verification was performed:
- [x] Verified that the `gum choose` menu displays the new baud rate options.
- [x] Confirmed the `arduino-cli monitor` command correctly receives the selected baud rate.
- [x] Checked that selecting a rate works and the UI returns to the main menu correctly after closing the monitor.

## Are there any user-facing changes?

Yes. The "Serial Monitor" menu now presents a more complete list of standard baud rates for selection.
